### PR TITLE
use text in place of missingh

### DIFF
--- a/Language/Hakaru/Simplify.hs
+++ b/Language/Hakaru/Simplify.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable, CPP #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, DeriveDataTypeable, CPP, OverloadedStrings #-}
 {-# OPTIONS -Wall #-}
 
 module Language.Hakaru.Simplify
@@ -22,7 +22,7 @@ import Language.Hakaru.PrettyPrint (runPrettyPrintNamesPrec)
 import System.IO (stderr, hPrint, hPutStrLn)
 import Data.Typeable (Typeable, typeOf)
 import Data.List (tails, stripPrefix)
-import Data.List.Utils (replace)
+import Data.Text (replace, pack, unpack)
 import Data.Char (isSpace)
 import System.MapleSSH (maple)
 import Language.Haskell.Interpreter.Unsafe (unsafeRunInterpreterWithArgs)
@@ -97,9 +97,9 @@ closeLoop s = action where
     case result of Left err -> throw (InterpreterException err s')
                    Right a -> return a
   s' = s ++ " :: " ++ typeStr
-  typeStr = replace ":" "Cons"
-          $ replace "[]" "Nil"
-          $ show (typeOf (getArg action))
+  typeStr = unpack $ replace ":" "Cons"
+                   $ replace "[]" "Nil"
+                   $ pack (show (typeOf (getArg action)))
 
 mkTypeString :: (Simplifiable a) => String -> a -> String
 mkTypeString s t = "Typed(" ++ s ++ ", " ++ mapleType t ++ ")"

--- a/hakaru.cabal
+++ b/hakaru.cabal
@@ -79,7 +79,7 @@ library
 -- integration used in LH.Sample
 -- ghc-prim is used in LH.RoundTrip
 -- tagged is used in LH.Embed
--- MissingH is used in LH.Simplify
+
   build-depends:       base >=4.6 && <5.0, 
                        Cabal >= 1.16,
                        ghc-prim >= 0.3 && < 0.4,
@@ -109,8 +109,7 @@ library
                        HUnit >= 1.2 && < 2.0,
                        mtl >= 2.1,
                        tagged >= 0.7 && < 1.0,
-                       generics-sop >= 0.1.0,
-                       MissingH >= 0.18.6
+                       generics-sop >= 0.1.0
 
 
   if flag(patchedHint)


### PR DESCRIPTION
The text package exports a `replace` and is used elsewhere.