### PR TITLE
Improve performance of the Hakaru Prelude

### DIFF
--- a/haskell/Language/Hakaru/Runtime/Prelude.hs
+++ b/haskell/Language/Hakaru/Runtime/Prelude.hs
@@ -121,7 +121,8 @@ newtype Branch a b =
 ptrue, pfalse :: a -> Branch Bool a
 ptrue  b = Branch { extract = extractBool True  b }
 pfalse b = Branch { extract = extractBool False b }
-{-# INLINE ptrue, pfalse #-}
+{-# INLINE ptrue  #-}
+{-# INLINE pfalse #-}
 
 extractBool :: Bool -> a -> Bool -> Maybe a
 extractBool b a p | p == b     = Just a  

--- a/haskell/Language/Hakaru/Runtime/Prelude.hs
+++ b/haskell/Language/Hakaru/Runtime/Prelude.hs
@@ -39,56 +39,73 @@ type instance MayBoxVec (a,b)        = MinBoxVec (MayBoxVec a) (MayBoxVec b)
 
 lam :: (a -> b) -> a -> b
 lam = id
+{-# INLINE lam #-}
 
 app :: (a -> b) -> a -> b
 app f x = f x
+{-# INLINE app #-}
 
 let_ :: a -> (a -> b) -> b
 let_ x f = let x1 = x in f x1
+{-# INLINE let_ #-}
 
 ann_ :: a -> b -> b
 ann_ _ a = a
+{-# INLINE ann_ #-}
 
 newtype Measure a = Measure { unMeasure :: MWC.GenIO -> IO (Maybe a) }
 
 instance Functor Measure where
     fmap  = liftM
+    {-# INLINE fmap #-}
 
 instance Applicative Measure where
     pure x = Measure $ \_ -> return (Just x)
+    {-# INLINE pure #-}
     (<*>)  = ap
+    {-# INLINE (<*>) #-}
 
 instance Monad Measure where
     return  = pure
+    {-# INLINE return #-}
     m >>= f = Measure $ \g -> do
                           Just x <- unMeasure m g
                           unMeasure (f x) g
+    {-# INLINE (>>=) #-}
 
 makeMeasure :: (MWC.GenIO -> IO a) -> Measure a
 makeMeasure f = Measure $ \g -> Just <$> f g
+{-# INLINE makeMeasure #-}
 
 uniform :: Double -> Double -> Measure Double
 uniform lo hi = makeMeasure $ MWC.uniformR (lo, hi)
+{-# INLINE uniform #-}
 
 normal :: Double -> Double -> Measure Double
 normal mu sd = makeMeasure $ MWCD.normal mu sd
+{-# INLINE normal #-}
 
 beta :: Double -> Double -> Measure Double
 beta a b = makeMeasure $ MWCD.beta a b
+{-# INLINE beta #-}
 
 gamma :: Double -> Double -> Measure Double
 gamma a b = makeMeasure $ MWCD.gamma a b
+{-# INLINE gamma #-}
 
 categorical :: MayBoxVec Double Double -> Measure Int
 categorical a = makeMeasure (\g -> fromIntegral <$> MWCD.categorical a g)
+{-# INLINE categorical #-}
 
 plate :: (G.Vector (MayBoxVec a) a) =>
          Int -> (Int -> Measure a) -> Measure (MayBoxVec a a)
 plate n f = G.generateM (fromIntegral n) $ \x ->
              f (fromIntegral x)
+{-# INLINE plate #-}
 
 pair :: a -> b -> (a, b)
 pair = (,)
+{-# INLINE pair #-}
 
 true, false :: Bool
 true  = True
@@ -104,10 +121,12 @@ newtype Branch a b =
 ptrue, pfalse :: a -> Branch Bool a
 ptrue  b = Branch { extract = extractBool True  b }
 pfalse b = Branch { extract = extractBool False b }
+{-# INLINE ptrue, pfalse #-}
 
 extractBool :: Bool -> a -> Bool -> Maybe a
 extractBool b a p | p == b     = Just a  
                   | otherwise  = Nothing
+{-# INLINE extractBool #-}
 
 ppair :: Pattern -> Pattern -> (x -> y -> b) -> Branch (x,y) b
 ppair PVar  PVar c = Branch { extract = (\(x,y) -> Just (c x y)) }
@@ -130,18 +149,22 @@ case_ e bs_      = go bs_
 
 branch :: (c -> Branch a b) -> c -> Branch a b
 branch pat body = pat body
+{-# INLINE branch #-}
 
 dirac :: a -> Measure a
 dirac = return
+{-# INLINE dirac #-}
 
 pose :: Double -> Measure a -> Measure a
 pose _ a = a
+{-# INLINE pose #-}
 
 superpose :: [(Double, Measure a)]
           -> Measure a
 superpose pms = do
   i <- makeMeasure $ MWCD.categorical (U.fromList $ map fst pms)
   snd (pms !! i)
+{-# INLINE superpose #-}
 
 reject :: Measure a
 reject = Measure $ \_ -> return Nothing
@@ -194,12 +217,15 @@ array
     -> (Int -> a)
     -> MayBoxVec a a
 array n f = G.generate (fromIntegral n) (f . fromIntegral)
+{-# INLINE array #-}
 
 (!) :: (G.Vector (MayBoxVec a) a) => MayBoxVec a a -> Int -> a
 a ! b = a G.! (fromIntegral b)
+{-# INLINE (!) #-}
 
 size :: (G.Vector (MayBoxVec a) a) => MayBoxVec a a -> Int
 size v = fromIntegral (G.length v)
+{-# INLINE size #-}
 
 product
     :: Num a
@@ -208,6 +234,7 @@ product
     -> (Int -> a)
     -> a
 product a b f = F.foldl' (\x y -> x * f y) 1 [a .. b-1]
+{-# INLINE product #-}
 
 summate
     :: Num a
@@ -216,6 +243,7 @@ summate
     -> (Int -> a)
     -> a
 summate a b f = F.foldl' (\x y -> x + f y) 0 [a .. b-1]
+{-# INLINE summate #-}
 
 run :: Show a
     => MWC.GenIO


### PR DESCRIPTION
This PR provides two performance improvements for Hakaru

1. `case_` is rewritten so that the GHC can fully inline it in the common case of testing a boolean condition. The `go` worker function cannot be inlined generally since it is recursive. This currently only works for cases with 1 or 2 alternatives, I just went with the simplest thing that works.

2. Ensure functions from the Prelude in general are inlined. GHC is conservative with cross module inlining when an export list is not provided. I've just added `INLINE` pragmas to most of the important functions.  For good performance, looping constructs like `summate` and `product` must be inlined to specialize on the worker function. The same goes for combinators over fusable operations.

These two optimizations provide a 16.7x speedup on the Haskell code generated by the `naive_bayes` benchmark.

