### PR TITLE
Erlang test5

### DIFF
--- a/haskell/Tests/RoundTrip.hs
+++ b/haskell/Tests/RoundTrip.hs
@@ -211,6 +211,11 @@ testStdChiSqRelations = test [
     "t_rayleigh_to_stdChiSq"     ~: testConcreteFiles "tests/RoundTrip2/t_rayleigh_to_stdChiSq.0.hk" "tests/RoundTrip2/t_rayleigh_to_stdChiSq.expected.hk"        
     ]
 
+testErlangRelations :: Test
+testErlangRelations = test [
+    "t_stdChiSq_to_gamma"   ~: testConcreteFiles "tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk" "tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk"        
+    ]
+
 testOther :: Test
 testOther = test [
     "t82"              ~: testConcreteFiles "tests/RoundTrip/t82.0.hk" "tests/RoundTrip/t82.expected.hk",

--- a/haskell/Tests/RoundTrip.hs
+++ b/haskell/Tests/RoundTrip.hs
@@ -213,7 +213,7 @@ testStdChiSqRelations = test [
 
 testErlangRelations :: Test
 testErlangRelations = test [
-    "t_stdChiSq_to_gamma"   ~: testConcreteFiles "tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk" "tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk"        
+    "t_erlang_to_stdChiSq"   ~: testConcreteFiles "tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk" "tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk"        
     ]
 
 testOther :: Test

--- a/tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk
+++ b/tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk
@@ -1,0 +1,9 @@
+def erlang(shape prob, scale nat):
+	return gamma(shape, nat2prob(scale))
+
+fn k nat:
+	fn lambda prob:
+		X <~ erlang(lambda,k)
+		return(2*lambda*X)
+
+

--- a/tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk
+++ b/tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk
@@ -1,9 +1,9 @@
-def erlang(shape prob, scale nat):
-	gamma(shape, nat2prob(scale))
+def erlang(shape nat, scale prob) measure(prob):
+	gamma(nat2prob(shape), scale)
 
 fn k nat:
 	fn lambda prob:
-		X <~ erlang(lambda,k)
+		X <~ erlang(k,lambda)
 		return 2*lambda*X
 
 

--- a/tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk
+++ b/tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk
@@ -1,9 +1,9 @@
 def erlang(shape prob, scale nat):
-	return gamma(shape, nat2prob(scale))
+	gamma(shape, nat2prob(scale))
 
 fn k nat:
 	fn lambda prob:
 		X <~ erlang(lambda,k)
-		return(2*lambda*X)
+		return 2*lambda*X
 
 

--- a/tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk
+++ b/tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk
@@ -1,0 +1,10 @@
+def chiSq_iid(n nat, mean real, stdev prob):
+	q <~ plate _ of n: normal(mean,stdev)
+	return summate i from 0 to size(q): 
+		((q[i]-mean)/stdev)^2
+
+def standardChiSq(n nat):
+	chiSq_iid(n,0,1)
+
+fn k nat:
+	standardChiSq(2*k)

--- a/tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk
+++ b/tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk
@@ -1,10 +1,3 @@
-def chiSq_iid(n nat, mean real, stdev prob):
-	q <~ plate _ of n: normal(mean,stdev)
-	return summate i from 0 to size(q): 
-		((q[i]-mean)/stdev)^2
-
-def standardChiSq(n nat):
-	chiSq_iid(n,0,1)
-
 fn k nat:
-	standardChiSq(2*k)
+	q <~ plate _ of 2*k: normal(0,1)
+	return summate i from 0 to size(q): (q[i])^2

--- a/tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk
+++ b/tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk
@@ -1,3 +1,3 @@
 fn k nat:
 	q <~ plate _ of 2*k: normal(0,1)
-	return summate i from 0 to size(q): (q[i])^2
+	return summate i from 0 to size(q): (q[i])^2   # our implementation of stdChiSq


### PR DESCRIPTION
This branch includes additions that would be used to test the seventh relationship here:
[https://en.wikipedia.org/wiki/Erlang_distribution#Related_distributions](url)

The files tests/RoundTrip2/t_erlang_to_stdChiSq.0.hk and tests/RoundTrip2/t_erlang_to_stdChiSq.expected.hk are the test and expected respectively.

This test was successful and did not produce anything in the logs.

