### PR TITLE
adding test for cauchy reciprocal transformation

### DIFF
--- a/haskell/Tests/RoundTrip.hs
+++ b/haskell/Tests/RoundTrip.hs
@@ -211,6 +211,11 @@ testStdChiSqRelations = test [
     "t_rayleigh_to_stdChiSq"     ~: testConcreteFiles "tests/RoundTrip2/t_rayleigh_to_stdChiSq.0.hk" "tests/RoundTrip2/t_rayleigh_to_stdChiSq.expected.hk"        
     ]
 
+testCauchyRelations :: Test 
+testCauchyRelations = test [
+    "t_cauchy_reciprocal_transformation" ~: testConcreteFiles "tests/RoundTrip2/t_cauchy_reciprocal_transformation.0.hk" "tests/RoundTrip2/t_cauchy_reciprocal_transformation.expected.hk"
+    ]
+
 testOther :: Test
 testOther = test [
     "t82"              ~: testConcreteFiles "tests/RoundTrip/t82.0.hk" "tests/RoundTrip/t82.expected.hk",
@@ -253,6 +258,7 @@ allTests = test
     , testMeasureNat
     , testMeasureInt
     , testStdChiSqRelations
+    , testCauchyRelations
     , testOther
     ]
 

--- a/tests/RoundTrip2/t_cauchy_reciprocal_transformation.0.hk
+++ b/tests/RoundTrip2/t_cauchy_reciprocal_transformation.0.hk
@@ -1,0 +1,15 @@
+def stdNormal():
+	p <~ normal(0, 1)
+	return p
+
+def stdCauchy():
+	X1 <~ stdNormal()
+	X2 <~ stdNormal()
+	return X1/X2
+
+def cauchy(a real, alpha prob):
+	X <~ stdCauchy()
+	return a + alpha*X
+
+X <~ cauchy(0, 2)
+return 1 / X

--- a/tests/RoundTrip2/t_cauchy_reciprocal_transformation.expected.hk
+++ b/tests/RoundTrip2/t_cauchy_reciprocal_transformation.expected.hk
@@ -1,0 +1,15 @@
+def stdNormal():
+	p <~ normal(0, 1)
+	return p
+
+def stdCauchy():
+	X1 <~ stdNormal()
+	X2 <~ stdNormal()
+	return X1/X2
+
+def cauchy(a real, alpha prob):
+	X <~ stdCauchy()
+	return a + alpha*X
+
+X <~ cauchy(0, 1/2)
+return X


### PR DESCRIPTION
Failure in: 6:RoundTrip:7:3:t_cauchy_reciprocal_transformation:0
haskell/Tests/TestTools.hs:130
expected:
stdNormal = p <~ normal(nat2real(0), nat2prob(1))
return p
stdCauchy = X1 <~ stdNormal
X2 <~ stdNormal
return X1 / X2
cauchy = fn a real:
fn alpha prob:
X <~ stdCauchy
return a + prob2real(alpha) * X
X <~ cauchy(nat2real(0), 1/2)
return X
but got:
p5 <~ normal(+0/1, 1/1)
p3 <~ normal(+0/1, 1/1)
return p5 / p3 * (+1/2)
Cases: 338 Tried: 293 Errors: 2 Failures: 26

Failure in: 6:RoundTrip:7:3:t_cauchy_reciprocal_transformation:1
haskell/Tests/TestTools.hs:130
expected:
stdNormal = p <~ normal(nat2real(0), nat2prob(1))
return p
stdCauchy = X1 <~ stdNormal
X2 <~ stdNormal
return X1 / X2
cauchy = fn a real:
fn alpha prob:
X <~ stdCauchy
return a + prob2real(alpha) * X
X <~ cauchy(nat2real(0), 1/2)
return X
but got:
p5 <~ normal(+0/1, 1/1)
p3 <~ normal(+0/1, 1/1)
return 1/ p5 * p3 * (+1/2)
Cases: 338 Tried: 294 Errors: 2 Failures: 27
Cases: 338 Tried: 295 Errors: 2 Failures: 27
Cases: 338 Tried: 296 Errors: 2 Failures: 27
Cases: 338 Tried: 297 Errors: 2 Failures: 27