### PR TITLE
Cauchy test 4

### DIFF
--- a/haskell/Tests/RoundTrip.hs
+++ b/haskell/Tests/RoundTrip.hs
@@ -211,6 +211,11 @@ testStdChiSqRelations = test [
     "t_rayleigh_to_stdChiSq"     ~: testConcreteFiles "tests/RoundTrip2/t_rayleigh_to_stdChiSq.0.hk" "tests/RoundTrip2/t_rayleigh_to_stdChiSq.expected.hk"        
     ]
 
+testCauchyRelations :: Test 
+testCauchyRelations = test [
+    "t_cauchy_to_students_t" ~: testConcreteFiles "tests/RoundTrip2/t_cauchy_to_students_t.0.hk" "tests/RoundTrip2/t_cauchy_to_students_t.expected.hk"
+    ]
+
 testOther :: Test
 testOther = test [
     "t82"              ~: testConcreteFiles "tests/RoundTrip/t82.0.hk" "tests/RoundTrip/t82.expected.hk",
@@ -253,6 +258,7 @@ allTests = test
     , testMeasureNat
     , testMeasureInt
     , testStdChiSqRelations
+    , testCauchyRelations
     , testOther
     ]
 

--- a/tests/RoundTrip2/t_cauchy_to_students_t.0.hk
+++ b/tests/RoundTrip2/t_cauchy_to_students_t.0.hk
@@ -1,0 +1,14 @@
+def stdNormal():
+	p <~ normal(0, 1)
+	return p
+
+def stdCauchy():
+	X1 <~ stdNormal()
+	X2 <~ stdNormal()
+	return X1/X2
+
+def cauchy(a real, alpha prob):
+	X <~ stdCauchy()
+	return a + alpha*X
+
+cauchy(0, 1)

--- a/tests/RoundTrip2/t_cauchy_to_students_t.expected.hk
+++ b/tests/RoundTrip2/t_cauchy_to_students_t.expected.hk
@@ -1,0 +1,21 @@
+def chiSq_iid(n nat, mean real, stdev prob):
+	q <~ plate _ of n: normal(mean,stdev)
+	return summate i from 0 to size(q): 
+		((q[i]-mean)/stdev)^2
+
+def standardChiSq(n nat):
+	chiSq_iid(n,0,1)
+
+def standardChi(n nat):
+	q <~ standardChiSq(n)
+	return sqrt(real2prob(q))
+
+def nonCentralT(n nat, delta prob):
+	U <~ normal(0,1)
+	X <~ standardChi(n)
+	return (U + delta)*sqrt(n)/(X)
+
+def t(n nat):
+	return nonCentralT(n,0)
+
+t(1)


### PR DESCRIPTION
### Failure in: 6:RoundTrip:7:0:t_cauchy_to_students_t:0
haskell/Tests/TestTools.hs:130
expected:
chiSq_iid = fn n nat:
            fn mean real:
            fn stdev prob:
            q <~ plate _ of n: normal(mean, stdev)
            return summate i from 0 to size(q):
                   ((q[i] - mean) * prob2real(1/ stdev)) ^ 2
standardChiSq = fn n nat: chiSq_iid(n, nat2real(0), nat2prob(1))
standardChi = fn n nat:
              q <~ standardChiSq(n)
              return sqrt(real2prob(q))
nonCentralT = fn n nat:
              fn delta prob:
              U <~ normal(nat2real(0), nat2prob(1))
              X <~ standardChi(n)
              return (U + prob2real(delta))
                     * prob2real(sqrt(nat2prob(n)))
                     * prob2real(1/ X)
t = fn n nat: nonCentralT(n, nat2prob(0))
t(1)
but got:
U7 <~ normal(+0/1, 1/1)
q305 <~ normal(+0/1, 1/1)
return U7 * prob2real(1/ abs(q305))
Cases: 342  Tried: 293  Errors: 2  Failures: 25
                                               
### Failure in: 6:RoundTrip:7:0:t_cauchy_to_students_t:1
haskell/Tests/TestTools.hs:130
expected:
chiSq_iid = fn n nat:
            fn mean real:
            fn stdev prob:
            q <~ plate _ of n: normal(mean, stdev)
            return summate i from 0 to size(q):
                   ((q[i] - mean) * prob2real(1/ stdev)) ^ 2
standardChiSq = fn n nat: chiSq_iid(n, nat2real(0), nat2prob(1))
standardChi = fn n nat:
              q <~ standardChiSq(n)
              return sqrt(real2prob(q))
nonCentralT = fn n nat:
              fn delta prob:
              U <~ normal(nat2real(0), nat2prob(1))
              X <~ standardChi(n)
              return (U + prob2real(delta))
                     * prob2real(sqrt(nat2prob(n)))
                     * prob2real(1/ X)
t = fn n nat: nonCentralT(n, nat2prob(0))
t(1)
but got:
p5 <~ normal(+0/1, 1/1)
p3 <~ normal(+0/1, 1/1)
return p5 / p3
Cases: 342  Tried: 294  Errors: 2  Failures: 26