### PR TITLE
Cauchy test 6

### DIFF
--- a/haskell/Tests/RoundTrip.hs
+++ b/haskell/Tests/RoundTrip.hs
@@ -258,6 +258,7 @@ allTests = test
     , testMeasureNat
     , testMeasureInt
     , testStdChiSqRelations
+    , testCauchyRelations
     , testOther
     ]
 

--- a/haskell/Tests/RoundTrip.hs
+++ b/haskell/Tests/RoundTrip.hs
@@ -211,6 +211,11 @@ testStdChiSqRelations = test [
     "t_rayleigh_to_stdChiSq"     ~: testConcreteFiles "tests/RoundTrip2/t_rayleigh_to_stdChiSq.0.hk" "tests/RoundTrip2/t_rayleigh_to_stdChiSq.expected.hk"        
     ]
 
+testCauchyRelations :: Test 
+testCauchyRelations = test [
+    "t_uniform_to_cauchy" ~: testConcreteFiles "tests/RoundTrip2/t_uniform_to_cauchy.0.hk" "tests/RoundTrip2/t_uniform_to_cauchy.expected.hk"
+    ]
+
 testOther :: Test
 testOther = test [
     "t82"              ~: testConcreteFiles "tests/RoundTrip/t82.0.hk" "tests/RoundTrip/t82.expected.hk",

--- a/tests/RoundTrip2/t_uniform_to_cauchy.0.hk
+++ b/tests/RoundTrip2/t_uniform_to_cauchy.0.hk
@@ -1,0 +1,2 @@
+X <~ uniform(0, 1)
+return tan(pi * (X - 1/2))

--- a/tests/RoundTrip2/t_uniform_to_cauchy.expected.hk
+++ b/tests/RoundTrip2/t_uniform_to_cauchy.expected.hk
@@ -1,0 +1,14 @@
+def stdNormal():
+	p <~ normal(0, 1)
+	return p
+
+def stdCauchy():
+	X1 <~ stdNormal()
+	X2 <~ stdNormal()
+	return X1/X2
+
+def cauchy(a real, alpha prob):
+	X <~ stdCauchy()
+	return a + alpha*X
+
+cauchy(0, 1)


### PR DESCRIPTION
### Failure in: 6:RoundTrip:7:2:t_uniform_to_cauchy:0
haskell/Tests/TestTools.hs:130
expected:
stdNormal = p <~ normal(nat2real(0), nat2prob(1))
            return p
stdCauchy = X1 <~ stdNormal
            X2 <~ stdNormal
            return X1 / X2
cauchy = fn a real:
         fn alpha prob:
         X <~ stdCauchy
         return a + prob2real(alpha) * X
cauchy(nat2real(0), nat2prob(1))
but got:
p5 <~ normal(+0/1, 1/1)
p3 <~ normal(+0/1, 1/1)
return p5 / p3
Cases: 342  Tried: 297  Errors: 2  Failures: 29
                                               
### Failure in: 6:RoundTrip:7:2:t_uniform_to_cauchy:1
haskell/Tests/TestTools.hs:130
expected:
stdNormal = p <~ normal(nat2real(0), nat2prob(1))
            return p
stdCauchy = X1 <~ stdNormal
            X2 <~ stdNormal
            return X1 / X2
cauchy = fn a real:
         fn alpha prob:
         X <~ stdCauchy
         return a + prob2real(alpha) * X
cauchy(nat2real(0), nat2prob(1))
but got:
X3 <~ uniform(+0/1, +1/1)
return tan(prob2real(pi) * (X3 + (-1/2)))
Cases: 342  Tried: 298  Errors: 2  Failures: 30
Cases: 342  Tried: 299  Errors: 2  Failures: 30
Cases: 342  Tried: 300  Errors: 2  Failures: 30
Cases: 342  Tried: 301  Errors: 2  Failures: 30